### PR TITLE
Improve layout with navigation and configurable grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import Dashboard from './pages/Dashboard';
+import SettingsPage from './pages/SettingsPage';
 import useStore from './store';
 
 const App: React.FC = () => {
@@ -12,6 +13,7 @@ const App: React.FC = () => {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/" element={user ? <Dashboard /> : <Navigate to="/login" />} />
+        <Route path="/settings" element={user ? <SettingsPage /> : <Navigate to="/login" />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/CageGrid.tsx
+++ b/src/components/CageGrid.tsx
@@ -1,13 +1,20 @@
 import React, { useState } from 'react';
-import { Box, Grid, Paper, Typography, Dialog, TextField, Button } from '@mui/material';
+import { Box, Paper, Typography, Dialog, Button, Select, MenuItem, Chip } from '@mui/material';
 import useStore, { Cage } from '../store';
 
-const gridSize = 3; // 3x3 grid demo
+const STATUS_OPTIONS = [
+  { label: '配对中', color: 'primary' },
+  { label: '隔离中', color: 'secondary' },
+  { label: '待鉴定', color: 'warning' },
+  { label: '已怀孕', color: 'success' },
+  { label: '临产', color: 'error' },
+];
 
 const CageGrid: React.FC = () => {
   const cages = useStore(state => state.cages);
   const addCage = useStore(state => state.addCage);
   const updateCage = useStore(state => state.updateCage);
+  const { rows, cols } = useStore(state => state.gridConfig);
 
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<Cage | null>(null);
@@ -39,34 +46,47 @@ const CageGrid: React.FC = () => {
   const renderCell = (row: number, col: number) => {
     const cage = cages.find(c => c.position.row === row && c.position.col === col);
     return (
-      <Grid item xs={4} key={`${row}-${col}`}> 
-        <Paper
-          onClick={() => handleCellClick(row, col)}
-          sx={{ height: 80, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
-        >
-          <Typography>{cage ? cage.id : '空'}</Typography>
-        </Paper>
-      </Grid>
+      <Paper
+        key={`${row}-${col}`}
+        onClick={() => handleCellClick(row, col)}
+        sx={{ height: 80, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+      >
+        <Typography>{cage ? cage.id : `空(${row},${col})`}</Typography>
+        {cage?.status && (
+          <Chip label={cage.status} color={STATUS_OPTIONS.find(o => o.label === cage.status)?.color as any} size="small" sx={{ mt: 0.5 }} />
+        )}
+      </Paper>
     );
   };
 
   return (
     <Box>
-      <Grid container spacing={2}>
-        {Array.from({ length: gridSize }).map((_, rowIdx) =>
-          Array.from({ length: gridSize }).map((_, colIdx) => renderCell(rowIdx + 1, colIdx + 1))
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${cols}, 1fr)`,
+          gap: 2,
+        }}
+      >
+        {Array.from({ length: rows }).map((_, rowIdx) =>
+          Array.from({ length: cols }).map((_, colIdx) => renderCell(rowIdx + 1, colIdx + 1))
         )}
-      </Grid>
+      </Box>
       <Dialog open={open} onClose={() => setOpen(false)}>
         <Box sx={{ p: 2, minWidth: 300 }}>
           <Typography variant="h6" gutterBottom>编辑笼位</Typography>
-          <TextField
-            label="状态"
+          <Select
             fullWidth
-            margin="normal"
             value={status}
-            onChange={e => setStatus(e.target.value)}
-          />
+            onChange={e => setStatus(e.target.value as string)}
+            displayEmpty
+            sx={{ mb: 2 }}
+          >
+            <MenuItem value="">无</MenuItem>
+            {STATUS_OPTIONS.map(opt => (
+              <MenuItem key={opt.label} value={opt.label}>{opt.label}</MenuItem>
+            ))}
+          </Select>
           <Button variant="contained" onClick={handleSave} sx={{ mr: 1 }}>保存</Button>
           <Button onClick={() => setOpen(false)}>取消</Button>
         </Box>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { AppBar, Toolbar, Typography, Button, Container } from '@mui/material';
+import { Link, useNavigate } from 'react-router-dom';
+import useStore from '../store';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const Layout: React.FC<Props> = ({ children }) => {
+  const navigate = useNavigate();
+  const logout = useStore(state => state.logout);
+  const user = useStore(state => state.user);
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <>
+      <AppBar position="static">
+        <Toolbar sx={{ display: 'flex', gap: 2 }}>
+          <Typography variant="h6" component={Link} to="/" color="inherit" sx={{ textDecoration: 'none', flexGrow: 1 }}>
+            MouseFit
+          </Typography>
+          {user && (
+            <>
+              <Button color="inherit" component={Link} to="/">笼位管理</Button>
+              <Button color="inherit" component={Link} to="/settings">设置</Button>
+              <Button color="inherit" onClick={handleLogout}>退出</Button>
+            </>
+          )}
+        </Toolbar>
+      </AppBar>
+      <Container sx={{ mt: 4 }}>{children}</Container>
+    </>
+  );
+};
+
+export default Layout;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Container, Typography, Button } from '@mui/material';
+import { Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import CageGrid from '../components/CageGrid';
 import useStore from '../store';
+import Layout from '../components/Layout';
 
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
-  const logout = useStore(state => state.logout);
   const user = useStore(state => state.user);
 
   if (!user) {
@@ -15,15 +15,12 @@ const Dashboard: React.FC = () => {
   }
 
   return (
-    <Container sx={{ mt: 4 }}>
+    <Layout>
       <Typography variant="h4" gutterBottom>
         笼位管理
       </Typography>
-      <Button variant="outlined" onClick={() => { logout(); navigate('/login'); }} sx={{ mb: 2 }}>
-        退出登录
-      </Button>
       <CageGrid />
-    </Container>
+    </Layout>
   );
 };
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { TextField, Button, Typography } from '@mui/material';
+import Layout from '../components/Layout';
+import useStore from '../store';
+
+const SettingsPage: React.FC = () => {
+  const { rows, cols } = useStore(state => state.gridConfig);
+  const setGridConfig = useStore(state => state.setGridConfig);
+
+  const [r, setR] = useState(rows);
+  const [c, setC] = useState(cols);
+
+  const handleSave = () => {
+    setGridConfig(r, c);
+  };
+
+  return (
+    <Layout>
+      <Typography variant="h5" gutterBottom>笼架设置</Typography>
+      <TextField
+        label="行数"
+        type="number"
+        value={r}
+        onChange={e => setR(Number(e.target.value))}
+        sx={{ mr: 2, width: 100 }}
+      />
+      <TextField
+        label="列数"
+        type="number"
+        value={c}
+        onChange={e => setC(Number(e.target.value))}
+        sx={{ mr: 2, width: 100 }}
+      />
+      <Button variant="contained" onClick={handleSave}>保存</Button>
+    </Layout>
+  );
+};
+
+export default SettingsPage;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -27,11 +27,13 @@ export interface User {
 interface State {
   cages: Cage[];
   mice: Mouse[];
+  gridConfig: { rows: number; cols: number };
   user?: User;
   login: (username: string, password: string) => boolean;
   logout: () => void;
   addCage: (cage: Cage) => void;
   updateCage: (cage: Cage) => void;
+  setGridConfig: (rows: number, cols: number) => void;
   addMouse: (mouse: Mouse) => void;
   updateMouse: (mouse: Mouse) => void;
 }
@@ -41,6 +43,7 @@ const useStore = create<State>()(
     (set, get) => ({
       cages: [],
       mice: [],
+      gridConfig: { rows: 3, cols: 3 },
       user: undefined,
       login: (username: string, password: string) => {
         if (username === 'admin' && password === 'admin') {
@@ -59,6 +62,8 @@ const useStore = create<State>()(
         set({
           cages: get().cages.map(c => (c.id === cage.id ? cage : c)),
         }),
+      setGridConfig: (rows: number, cols: number) =>
+        set({ gridConfig: { rows, cols } }),
       addMouse: (mouse: Mouse) => set({ mice: [...get().mice, mouse] }),
       updateMouse: (mouse: Mouse) =>
         set({ mice: get().mice.map(m => (m.id === mouse.id ? mouse : m)) }),


### PR DESCRIPTION
## Summary
- add global layout with navigation bar
- allow customizing cage grid rows/columns
- show color-coded cage status chips
- add settings page and update dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68765140208883229c782407c1d0aa52