### PR TITLE
Add mouse panel with drag-and-drop cages

### DIFF
--- a/src/components/CageGrid.tsx
+++ b/src/components/CageGrid.tsx
@@ -14,6 +14,9 @@ const CageGrid: React.FC = () => {
   const cages = useStore(state => state.cages);
   const addCage = useStore(state => state.addCage);
   const updateCage = useStore(state => state.updateCage);
+  const setSelectedCage = useStore(state => state.setSelectedCage);
+  const moveMouse = useStore(state => state.moveMouse);
+  const selectedCageId = useStore(state => state.selectedCageId);
   const { rows, cols } = useStore(state => state.gridConfig);
 
   const [open, setOpen] = useState(false);
@@ -21,6 +24,11 @@ const CageGrid: React.FC = () => {
   const [status, setStatus] = useState('');
 
   const handleCellClick = (row: number, col: number) => {
+    const cage = cages.find(c => c.position.row === row && c.position.col === col);
+    setSelectedCage(cage ? cage.id : undefined);
+  };
+
+  const handleCellDoubleClick = (row: number, col: number) => {
     const cage = cages.find(c => c.position.row === row && c.position.col === col);
     if (cage) {
       setEditing(cage);
@@ -49,7 +57,24 @@ const CageGrid: React.FC = () => {
       <Paper
         key={`${row}-${col}`}
         onClick={() => handleCellClick(row, col)}
-        sx={{ height: 80, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+        onDoubleClick={() => handleCellDoubleClick(row, col)}
+        onDragOver={e => e.preventDefault()}
+        onDrop={e => {
+          const mouseId = e.dataTransfer.getData('text/plain');
+          if (mouseId) moveMouse(mouseId, cage ? cage.id : `C${row}${col}`);
+          setSelectedCage(cage ? cage.id : `C${row}${col}`);
+        }}
+        sx={{
+          height: 80,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          border: selectedCageId === (cage ? cage.id : `C${row}${col}`)
+            ? '2px solid #1976d2'
+            : '1px solid #ccc',
+        }}
       >
         <Typography>{cage ? cage.id : `空(${row},${col})`}</Typography>
         {cage?.status && (

--- a/src/components/MouseCard.tsx
+++ b/src/components/MouseCard.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { Card, CardContent, Typography, Button, Dialog, TextField } from '@mui/material';
+import useStore, { Mouse } from '../store';
+
+interface Props {
+  mouse: Mouse;
+}
+
+const MouseCard: React.FC<Props> = ({ mouse }) => {
+  const updateMouse = useStore(state => state.updateMouse);
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState(mouse);
+
+  const handleSave = () => {
+    updateMouse(data);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Card
+        draggable
+        onDragStart={e => e.dataTransfer.setData('text/plain', mouse.id)}
+        sx={{ minWidth: 200, mr: 2 }}
+      >
+        <CardContent onDoubleClick={() => setOpen(true)} sx={{ p: 1 }}>
+          <Typography variant="subtitle1">耳标: {mouse.earTag}</Typography>
+          <Typography variant="body2">品系: {mouse.strain}</Typography>
+          <Typography variant="body2">性别: {mouse.gender}</Typography>
+          <Typography variant="body2">基因型: {mouse.genotypeStatus}</Typography>
+          <Typography variant="body2">{mouse.notes}</Typography>
+          <Button size="small" onClick={() => setOpen(true)} sx={{ mt: 1 }}>
+            编辑
+          </Button>
+        </CardContent>
+      </Card>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <CardContent sx={{ minWidth: 250 }}>
+          <TextField
+            label="耳标"
+            fullWidth
+            margin="dense"
+            value={data.earTag}
+            onChange={e => setData({ ...data, earTag: e.target.value })}
+          />
+          <TextField
+            label="品系"
+            fullWidth
+            margin="dense"
+            value={data.strain}
+            onChange={e => setData({ ...data, strain: e.target.value })}
+          />
+          <TextField
+            label="性别"
+            fullWidth
+            margin="dense"
+            value={data.gender}
+            onChange={e => setData({ ...data, gender: e.target.value as 'M' | 'F' })}
+          />
+          <TextField
+            label="基因型"
+            fullWidth
+            margin="dense"
+            value={data.genotypeStatus}
+            onChange={e => setData({ ...data, genotypeStatus: e.target.value })}
+          />
+          <TextField
+            label="备注"
+            fullWidth
+            margin="dense"
+            value={data.notes}
+            onChange={e => setData({ ...data, notes: e.target.value })}
+          />
+          <Button variant="contained" onClick={handleSave} sx={{ mt: 1, mr: 1 }}>
+            保存
+          </Button>
+          <Button onClick={() => setOpen(false)} sx={{ mt: 1 }}>
+            取消
+          </Button>
+        </CardContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default MouseCard;

--- a/src/components/MousePanel.tsx
+++ b/src/components/MousePanel.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import useStore from '../store';
+import MouseCard from './MouseCard';
+
+const MousePanel: React.FC = () => {
+  const cages = useStore(state => state.cages);
+  const mice = useStore(state => state.mice);
+  const selectedCageId = useStore(state => state.selectedCageId);
+
+  const cage = cages.find(c => c.id === selectedCageId);
+  const list = cage ? cage.mice.map(id => mice.find(m => m.id === id)).filter(Boolean) : [];
+
+  if (!cage) {
+    return <Typography color="text.secondary">请选择笼位查看小鼠信息</Typography>;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', overflowX: 'auto', p: 1 }}>
+      {list.map(mouse => (
+        <MouseCard key={mouse!.id} mouse={mouse!} />
+      ))}
+    </Box>
+  );
+};
+
+export default MousePanel;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Typography } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import CageGrid from '../components/CageGrid';
+import MousePanel from '../components/MousePanel';
 import useStore from '../store';
 import Layout from '../components/Layout';
 
@@ -19,7 +20,14 @@ const Dashboard: React.FC = () => {
       <Typography variant="h4" gutterBottom>
         笼位管理
       </Typography>
-      <CageGrid />
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '70vh' }}>
+        <Box sx={{ flex: 2, overflow: 'auto' }}>
+          <CageGrid />
+        </Box>
+        <Box sx={{ flex: 1, mt: 2, overflow: 'hidden' }}>
+          <MousePanel />
+        </Box>
+      </Box>
     </Layout>
   );
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,6 +29,7 @@ interface State {
   mice: Mouse[];
   gridConfig: { rows: number; cols: number };
   user?: User;
+  selectedCageId?: string;
   login: (username: string, password: string) => boolean;
   logout: () => void;
   addCage: (cage: Cage) => void;
@@ -36,15 +37,75 @@ interface State {
   setGridConfig: (rows: number, cols: number) => void;
   addMouse: (mouse: Mouse) => void;
   updateMouse: (mouse: Mouse) => void;
+  setSelectedCage: (id: string | undefined) => void;
+  moveMouse: (mouseId: string, targetCageId: string) => void;
 }
 
 const useStore = create<State>()(
   persist(
     (set, get) => ({
-      cages: [],
-      mice: [],
+      cages: [
+        { id: 'C11', position: { row: 1, col: 1 }, status: '配对中', mice: ['M001', 'M002'] },
+        { id: 'C12', position: { row: 1, col: 2 }, status: '隔离中', mice: ['M003'] },
+        { id: 'C13', position: { row: 1, col: 3 }, status: '待鉴定', mice: [] },
+        { id: 'C21', position: { row: 2, col: 1 }, status: '已怀孕', mice: [] },
+        { id: 'C22', position: { row: 2, col: 2 }, status: '临产', mice: ['M004', 'M005'] },
+      ],
+      mice: [
+        {
+          id: 'M001',
+          earTag: '001',
+          strain: 'C57BL/6',
+          gender: 'M',
+          birthDate: '2024-01-01',
+          parents: { father: 'F1', mother: 'M1' },
+          genotypeStatus: '待鉴定',
+          notes: '正常',
+        },
+        {
+          id: 'M002',
+          earTag: '002',
+          strain: 'C57BL/6',
+          gender: 'F',
+          birthDate: '2024-01-02',
+          parents: { father: 'F1', mother: 'M1' },
+          genotypeStatus: '待鉴定',
+          notes: '配对中',
+        },
+        {
+          id: 'M003',
+          earTag: '003',
+          strain: 'Balb/c',
+          gender: 'M',
+          birthDate: '2023-12-01',
+          parents: { father: 'F2', mother: 'M2' },
+          genotypeStatus: 'WT',
+          notes: '隔离观察',
+        },
+        {
+          id: 'M004',
+          earTag: '004',
+          strain: 'ICR',
+          gender: 'F',
+          birthDate: '2023-10-05',
+          parents: { father: 'F3', mother: 'M3' },
+          genotypeStatus: 'Het',
+          notes: '孕鼠',
+        },
+        {
+          id: 'M005',
+          earTag: '005',
+          strain: 'ICR',
+          gender: 'F',
+          birthDate: '2023-10-05',
+          parents: { father: 'F3', mother: 'M3' },
+          genotypeStatus: 'KO',
+          notes: '哺乳中',
+        },
+      ],
       gridConfig: { rows: 3, cols: 3 },
       user: undefined,
+      selectedCageId: 'C11',
       login: (username: string, password: string) => {
         if (username === 'admin' && password === 'admin') {
           set({ user: { username, role: 'admin' } });
@@ -67,6 +128,20 @@ const useStore = create<State>()(
       addMouse: (mouse: Mouse) => set({ mice: [...get().mice, mouse] }),
       updateMouse: (mouse: Mouse) =>
         set({ mice: get().mice.map(m => (m.id === mouse.id ? mouse : m)) }),
+      setSelectedCage: (id: string | undefined) => set({ selectedCageId: id }),
+      moveMouse: (mouseId: string, targetCageId: string) => {
+        const updatedCages = get().cages.map(c => {
+          let mice = c.mice;
+          if (mice.includes(mouseId)) {
+            mice = mice.filter(id => id !== mouseId);
+          }
+          if (c.id === targetCageId) {
+            mice = [...mice, mouseId];
+          }
+          return { ...c, mice };
+        });
+        set({ cages: updatedCages });
+      },
     }),
     { name: 'mousefit-storage' }
   )


### PR DESCRIPTION
## Summary
- add example cages and mice to store with new `selectedCageId`
- enable moving mice between cages via drag and drop
- highlight selected cage and edit cage on double‑click
- show list of mice in a bottom panel with editable cards
- adjust dashboard layout to keep cages in a fixed panel

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6876562272348322961af483e4141d2c