### PR TITLE
Implement rack tabs and theme toggle

### DIFF
--- a/src/components/CageGrid.tsx
+++ b/src/components/CageGrid.tsx
@@ -12,6 +12,7 @@ const STATUS_OPTIONS = [
 
 const CageGrid: React.FC = () => {
   const cages = useStore(state => state.cages);
+  const selectedRackId = useStore(state => state.selectedRackId);
   const addCage = useStore(state => state.addCage);
   const updateCage = useStore(state => state.updateCage);
   const setSelectedCage = useStore(state => state.setSelectedCage);
@@ -24,17 +25,21 @@ const CageGrid: React.FC = () => {
   const [status, setStatus] = useState('');
 
   const handleCellClick = (row: number, col: number) => {
-    const cage = cages.find(c => c.position.row === row && c.position.col === col);
+    const cage = cages.find(
+      c => c.rackId === selectedRackId && c.position.row === row && c.position.col === col
+    );
     setSelectedCage(cage ? cage.id : undefined);
   };
 
   const handleCellDoubleClick = (row: number, col: number) => {
-    const cage = cages.find(c => c.position.row === row && c.position.col === col);
+    const cage = cages.find(
+      c => c.rackId === selectedRackId && c.position.row === row && c.position.col === col
+    );
     if (cage) {
       setEditing(cage);
       setStatus(cage.status);
     } else {
-      setEditing({ id: `C${row}${col}`, position: { row, col }, status: '', mice: [] });
+      setEditing({ id: `C${row}${col}`, rackId: selectedRackId, position: { row, col }, status: '', mice: [] });
       setStatus('');
     }
     setOpen(true);
@@ -52,9 +57,12 @@ const CageGrid: React.FC = () => {
   };
 
   const renderCell = (row: number, col: number) => {
-    const cage = cages.find(c => c.position.row === row && c.position.col === col);
+    const cage = cages.find(
+      c => c.rackId === selectedRackId && c.position.row === row && c.position.col === col
+    );
     return (
       <Paper
+        variant="outlined"
         key={`${row}-${col}`}
         onClick={() => handleCellClick(row, col)}
         onDoubleClick={() => handleCellDoubleClick(row, col)}
@@ -85,7 +93,7 @@ const CageGrid: React.FC = () => {
   };
 
   return (
-    <Box>
+    <Box sx={{ border: 1, p: 1 }}>
       <Box
         sx={{
           display: 'grid',

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
-import { AppBar, Toolbar, Typography, Button, Container } from '@mui/material';
+import React, { useContext } from 'react';
+import { AppBar, Toolbar, Typography, Button, Container, IconButton, useTheme } from '@mui/material';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
 import { Link, useNavigate } from 'react-router-dom';
 import useStore from '../store';
+import { ColorModeContext } from '../main';
 
 interface Props {
   children: React.ReactNode;
@@ -11,6 +14,8 @@ const Layout: React.FC<Props> = ({ children }) => {
   const navigate = useNavigate();
   const logout = useStore(state => state.logout);
   const user = useStore(state => state.user);
+  const colorMode = useContext(ColorModeContext);
+  const theme = useTheme();
 
   const handleLogout = () => {
     logout();
@@ -31,6 +36,9 @@ const Layout: React.FC<Props> = ({ children }) => {
               <Button color="inherit" onClick={handleLogout}>退出</Button>
             </>
           )}
+          <IconButton color="inherit" onClick={colorMode.toggleColorMode}>
+            {theme.palette.mode === 'dark' ? <LightModeIcon /> : <DarkModeIcon />}
+          </IconButton>
         </Toolbar>
       </AppBar>
       <Container sx={{ mt: 4 }}>{children}</Container>

--- a/src/components/MouseCard.tsx
+++ b/src/components/MouseCard.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Card, CardContent, Typography, Button, Dialog, TextField } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { Card, CardContent, TextField, Select, MenuItem } from '@mui/material';
 import useStore, { Mouse } from '../store';
 
 interface Props {
@@ -8,78 +8,66 @@ interface Props {
 
 const MouseCard: React.FC<Props> = ({ mouse }) => {
   const updateMouse = useStore(state => state.updateMouse);
-  const [open, setOpen] = useState(false);
   const [data, setData] = useState(mouse);
 
-  const handleSave = () => {
-    updateMouse(data);
-    setOpen(false);
+  useEffect(() => {
+    setData(mouse);
+  }, [mouse]);
+
+  const handleChange = (key: keyof Mouse, value: any) => {
+    const updated = { ...data, [key]: value } as Mouse;
+    setData(updated);
+    updateMouse(updated);
   };
 
   return (
-    <>
-      <Card
-        draggable
-        onDragStart={e => e.dataTransfer.setData('text/plain', mouse.id)}
-        sx={{ minWidth: 200, mr: 2 }}
-      >
-        <CardContent onDoubleClick={() => setOpen(true)} sx={{ p: 1 }}>
-          <Typography variant="subtitle1">耳标: {mouse.earTag}</Typography>
-          <Typography variant="body2">品系: {mouse.strain}</Typography>
-          <Typography variant="body2">性别: {mouse.gender}</Typography>
-          <Typography variant="body2">基因型: {mouse.genotypeStatus}</Typography>
-          <Typography variant="body2">{mouse.notes}</Typography>
-          <Button size="small" onClick={() => setOpen(true)} sx={{ mt: 1 }}>
-            编辑
-          </Button>
-        </CardContent>
-      </Card>
-      <Dialog open={open} onClose={() => setOpen(false)}>
-        <CardContent sx={{ minWidth: 250 }}>
-          <TextField
-            label="耳标"
-            fullWidth
-            margin="dense"
-            value={data.earTag}
-            onChange={e => setData({ ...data, earTag: e.target.value })}
-          />
-          <TextField
-            label="品系"
-            fullWidth
-            margin="dense"
-            value={data.strain}
-            onChange={e => setData({ ...data, strain: e.target.value })}
-          />
-          <TextField
-            label="性别"
-            fullWidth
-            margin="dense"
-            value={data.gender}
-            onChange={e => setData({ ...data, gender: e.target.value as 'M' | 'F' })}
-          />
-          <TextField
-            label="基因型"
-            fullWidth
-            margin="dense"
-            value={data.genotypeStatus}
-            onChange={e => setData({ ...data, genotypeStatus: e.target.value })}
-          />
-          <TextField
-            label="备注"
-            fullWidth
-            margin="dense"
-            value={data.notes}
-            onChange={e => setData({ ...data, notes: e.target.value })}
-          />
-          <Button variant="contained" onClick={handleSave} sx={{ mt: 1, mr: 1 }}>
-            保存
-          </Button>
-          <Button onClick={() => setOpen(false)} sx={{ mt: 1 }}>
-            取消
-          </Button>
-        </CardContent>
-      </Dialog>
-    </>
+    <Card
+      variant="outlined"
+      draggable
+      onDragStart={e => e.dataTransfer.setData('text/plain', mouse.id)}
+      sx={{ minWidth: 200, mr: 2, p: 1 }}
+    >
+      <CardContent sx={{ p: 1 }}>
+        <TextField
+          label="耳标"
+          fullWidth
+          margin="dense"
+          value={data.earTag}
+          onChange={e => handleChange('earTag', e.target.value)}
+        />
+        <TextField
+          label="品系"
+          fullWidth
+          margin="dense"
+          value={data.strain}
+          onChange={e => handleChange('strain', e.target.value)}
+        />
+        <Select
+          fullWidth
+          margin="dense"
+          value={data.gender}
+          onChange={e => handleChange('gender', e.target.value as 'M' | 'F')}
+          sx={{ mt: 1 }}
+        >
+          <MenuItem value="M">M</MenuItem>
+          <MenuItem value="F">F</MenuItem>
+        </Select>
+        <TextField
+          label="基因型"
+          fullWidth
+          margin="dense"
+          value={data.genotypeStatus}
+          onChange={e => handleChange('genotypeStatus', e.target.value)}
+        />
+        <TextField
+          label="备注"
+          fullWidth
+          margin="dense"
+          value={data.notes}
+          onChange={e => handleChange('notes', e.target.value)}
+        />
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/components/MousePanel.tsx
+++ b/src/components/MousePanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Card } from '@mui/material';
 import useStore from '../store';
 import MouseCard from './MouseCard';
 
@@ -7,6 +7,8 @@ const MousePanel: React.FC = () => {
   const cages = useStore(state => state.cages);
   const mice = useStore(state => state.mice);
   const selectedCageId = useStore(state => state.selectedCageId);
+  const addMouse = useStore(state => state.addMouse);
+  const moveMouse = useStore(state => state.moveMouse);
 
   const cage = cages.find(c => c.id === selectedCageId);
   const list = cage ? cage.mice.map(id => mice.find(m => m.id === id)).filter(Boolean) : [];
@@ -15,11 +17,43 @@ const MousePanel: React.FC = () => {
     return <Typography color="text.secondary">请选择笼位查看小鼠信息</Typography>;
   }
 
+  const handleAdd = () => {
+    if (!selectedCageId) return;
+    const id = `M${Date.now()}`;
+    const newMouse = {
+      id,
+      earTag: '',
+      strain: '',
+      gender: 'M' as const,
+      birthDate: '',
+      parents: { father: '', mother: '' },
+      genotypeStatus: '',
+      notes: '',
+    };
+    addMouse(newMouse);
+    moveMouse(id, selectedCageId);
+  };
+
   return (
-    <Box sx={{ display: 'flex', overflowX: 'auto', p: 1 }}>
+    <Box sx={{ display: 'flex', overflowX: 'auto', p: 1, border: 1 }}>
       {list.map(mouse => (
         <MouseCard key={mouse!.id} mouse={mouse!} />
       ))}
+      <Card
+        variant="outlined"
+        onClick={handleAdd}
+        sx={{
+          minWidth: 200,
+          mr: 2,
+          border: '2px dashed',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+        }}
+      >
+        <Typography color="text.secondary">添加小鼠</Typography>
+      </Card>
     </Box>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,36 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import ReactDOM from 'react-dom/client';
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
 import App from './App';
+
+export const ColorModeContext = React.createContext({ toggleColorMode: () => {} });
+
+const Root = () => {
+  const [mode, setMode] = useState<'light' | 'dark'>('dark');
+  const colorMode = useMemo(
+    () => ({ toggleColorMode: () => setMode(prev => (prev === 'light' ? 'dark' : 'light')) }),
+    [],
+  );
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: { mode, primary: { main: '#4cc9cc' } },
+      }),
+    [mode],
+  );
+
+  return (
+    <ColorModeContext.Provider value={colorMode}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <App />
+      </ThemeProvider>
+    </ColorModeContext.Provider>
+  );
+};
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>,
 );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Box } from '@mui/material';
+import { Typography, Box, Tabs, Tab } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import CageGrid from '../components/CageGrid';
 import MousePanel from '../components/MousePanel';
@@ -9,6 +9,9 @@ import Layout from '../components/Layout';
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
   const user = useStore(state => state.user);
+  const cages = useStore(state => state.cages);
+  const selectedRackId = useStore(state => state.selectedRackId);
+  const setSelectedRack = useStore(state => state.setSelectedRack);
 
   if (!user) {
     navigate('/login');
@@ -20,6 +23,15 @@ const Dashboard: React.FC = () => {
       <Typography variant="h4" gutterBottom>
         笼位管理
       </Typography>
+      <Tabs
+        value={selectedRackId}
+        onChange={(_, v) => setSelectedRack(v)}
+        sx={{ mb: 2 }}
+      >
+        {[...new Set(cages.map(c => c.rackId))].map(id => (
+          <Tab key={id} value={id} label={id} />
+        ))}
+      </Tabs>
       <Box sx={{ display: 'flex', flexDirection: 'column', height: '70vh' }}>
         <Box sx={{ flex: 2, overflow: 'auto' }}>
           <CageGrid />

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 
 export interface Cage {
   id: string;
+  rackId: string;
   position: { row: number; col: number };
   status: string;
   mice: string[];
@@ -29,6 +30,7 @@ interface State {
   mice: Mouse[];
   gridConfig: { rows: number; cols: number };
   user?: User;
+  selectedRackId: string;
   selectedCageId?: string;
   login: (username: string, password: string) => boolean;
   logout: () => void;
@@ -38,6 +40,7 @@ interface State {
   addMouse: (mouse: Mouse) => void;
   updateMouse: (mouse: Mouse) => void;
   setSelectedCage: (id: string | undefined) => void;
+  setSelectedRack: (id: string) => void;
   moveMouse: (mouseId: string, targetCageId: string) => void;
 }
 
@@ -45,11 +48,13 @@ const useStore = create<State>()(
   persist(
     (set, get) => ({
       cages: [
-        { id: 'C11', position: { row: 1, col: 1 }, status: '配对中', mice: ['M001', 'M002'] },
-        { id: 'C12', position: { row: 1, col: 2 }, status: '隔离中', mice: ['M003'] },
-        { id: 'C13', position: { row: 1, col: 3 }, status: '待鉴定', mice: [] },
-        { id: 'C21', position: { row: 2, col: 1 }, status: '已怀孕', mice: [] },
-        { id: 'C22', position: { row: 2, col: 2 }, status: '临产', mice: ['M004', 'M005'] },
+        { id: 'C11', rackId: 'R1', position: { row: 1, col: 1 }, status: '配对中', mice: ['M001', 'M002'] },
+        { id: 'C12', rackId: 'R1', position: { row: 1, col: 2 }, status: '隔离中', mice: ['M003'] },
+        { id: 'C13', rackId: 'R1', position: { row: 1, col: 3 }, status: '待鉴定', mice: [] },
+        { id: 'C21', rackId: 'R1', position: { row: 2, col: 1 }, status: '已怀孕', mice: [] },
+        { id: 'C22', rackId: 'R1', position: { row: 2, col: 2 }, status: '临产', mice: ['M004', 'M005'] },
+        { id: 'D11', rackId: 'R2', position: { row: 1, col: 1 }, status: '', mice: [] },
+        { id: 'D12', rackId: 'R2', position: { row: 1, col: 2 }, status: '', mice: [] },
       ],
       mice: [
         {
@@ -105,6 +110,7 @@ const useStore = create<State>()(
       ],
       gridConfig: { rows: 3, cols: 3 },
       user: undefined,
+      selectedRackId: 'R1',
       selectedCageId: 'C11',
       login: (username: string, password: string) => {
         if (username === 'admin' && password === 'admin') {
@@ -129,6 +135,7 @@ const useStore = create<State>()(
       updateMouse: (mouse: Mouse) =>
         set({ mice: get().mice.map(m => (m.id === mouse.id ? mouse : m)) }),
       setSelectedCage: (id: string | undefined) => set({ selectedCageId: id }),
+      setSelectedRack: (id: string) => set({ selectedRackId: id }),
       moveMouse: (mouseId: string, targetCageId: string) => {
         const updatedCages = get().cages.map(c => {
           let mice = c.mice;


### PR DESCRIPTION
## Summary
- add MUI theme provider with dark mode and toggle button
- switch cage racks using tabs
- outline cage and mouse cards
- show inline editable fields for mice
- add "Add Mouse" card and border styles
- support multiple racks in store

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68765d76c974832291092094361618d2